### PR TITLE
Fix headers for pytest discovery

### DIFF
--- a/src/tests/test_address_generator.py
+++ b/src/tests/test_address_generator.py
@@ -1,3 +1,31 @@
+#!/usr/bin/env python3
+"""Tests for the Revolutionary Address Generator."""
+
+import pytest
+import numpy as np
+import time
+import statistics
+import hashlib
+from typing import Dict, List, Any, Tuple, Optional
+from unittest.mock import Mock, patch, MagicMock
+from dataclasses import dataclass
+import scipy.stats as stats
+from collections import Counter, defaultdict
+
+from src.core.address_generator import (
+    RevolutionaryAddressGenerator,
+    AddressGenerationResult,
+    SimilarityAddressSet,
+    AddressComponents,
+    AddressValidationResult,
+)
+from src.core.fingerprint_processor import FingerprintCharacteristics
+from src.tests import TestConfig, TestDataGenerator, TestUtils
+
+
+class TestAddressGeneratorEarly:
+    """Initial portion of the address generator tests."""
+
     def test_concurrent_address_generation(self, address_generator, diverse_test_characteristics):
         """Test concurrent address generation capability."""
         import threading

--- a/src/tests/test_o1_lookup.py
+++ b/src/tests/test_o1_lookup.py
@@ -1,3 +1,37 @@
+#!/usr/bin/env python3
+"""Tests for the Revolutionary O(1) lookup engine."""
+
+import pytest
+import numpy as np
+import time
+import statistics
+import threading
+import queue
+import hashlib
+from typing import Dict, List, Any, Tuple, Optional
+from unittest.mock import Mock, patch, MagicMock
+from dataclasses import dataclass
+import scipy.stats as stats
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from src.database.o1_lookup import (
+    RevolutionaryO1LookupEngine,
+    LookupResult,
+    AddressIndex,
+    CacheManager,
+    PerformanceMetrics,
+)
+from src.database.database_manager import FingerprintRecord
+from src.tests import TestConfig, TestDataGenerator, TestUtils
+
+
+class TestO1LookupEarly:
+    """Initial portion of lookup tests loaded from partial file."""
+
+    def placeholder(self):
+        """Placeholder method for truncated content."""
         assert result.lookup_time_ms <= TestConfig.O1_LOOKUP_TIME_THRESHOLD_MS
         assert result.cache_hit is not None  # Cache status should be tracked
         assert result.index_efficiency > 0.8  # Index should be highly efficient

--- a/src/tests/test_performance.py
+++ b/src/tests/test_performance.py
@@ -1,3 +1,40 @@
+#!/usr/bin/env python3
+"""System performance tests."""
+
+import pytest
+import numpy as np
+import time
+import statistics
+import threading
+import queue
+import psutil
+import gc
+from typing import Dict, List, Any, Tuple, Optional
+from unittest.mock import Mock, patch, MagicMock
+from dataclasses import dataclass
+import scipy.stats as stats
+import matplotlib.pyplot as plt
+import io
+import base64
+
+from src.web.app import O1FingerprintApp
+from src.core.fingerprint_processor import RevolutionaryFingerprintProcessor
+from src.database.database_manager import O1DatabaseManager
+from src.web.search_engine import RevolutionarySearchEngine
+from src.tests import TestConfig, TestDataGenerator, TestUtils
+
+@dataclass
+class PerformanceBenchmark:
+    """Performance benchmark result."""
+    pass
+
+
+class TestPerformanceEarly:
+    """Initial portion of the performance tests."""
+
+    def placeholder(self):
+        """Placeholder method for truncated content."""
+
         print(f"📊 SCALABILITY ADVANTAGE DEMONSTRATED")
         for comp in scalability_comparison:
             print(f"   {comp['database_size']:>6,} records: "


### PR DESCRIPTION
## Summary
- add missing imports and placeholder classes to `test_address_generator`, `test_o1_lookup`, `test_performance`
- ensure these test modules are valid python modules

## Testing
- `pytest -q` *(fails: SyntaxError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_684fac2983208326842d20f2daab2162