### PR TITLE
Fix README path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import re
 
 # Read the contents of README file
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text(encoding='utf-8')
+long_description = (this_directory / "readme.md").read_text(encoding='utf-8')
 
 # Read version from __init__.py
 def get_version():


### PR DESCRIPTION
## Summary
- update setup.py to reference `readme.md`

## Testing
- `python setup.py sdist` *(fails: ModuleNotFoundError: No module named 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_e_684fac25fb0c832680bd7204c628f557